### PR TITLE
Harden optimizer_k checkpoint loading in training resume path

### DIFF
--- a/train_eval.py
+++ b/train_eval.py
@@ -58,12 +58,13 @@ def train_eval_model(model,
     if len(optim_path) > 0:
         print('Loading optimizer state from {}'.format(optim_path))
         optimizer.load_state_dict(torch.load(optim_path))
-    if len(optim_k_path) > 0:
-        try:
+    if len(optim_k_path) > 0 and optimizer_k is not None:
+        optim_k_file = Path(optim_k_path)
+        if optim_k_file.exists():
             print('Loading optimizer_k state from {}'.format(optim_k_path))
             optimizer_k.load_state_dict(torch.load(optim_k_path))
-        except FileNotFoundError:
-            print('Creating new optimizer for AFA modules')
+        else:
+            print('optimizer_k state {} not found. Creating new optimizer for AFA modules'.format(optim_k_path))
 
     if optimizer_k is not None:
         scheduler = optim.lr_scheduler.MultiStepLR(optimizer,


### PR DESCRIPTION
### Motivation
- Make resume logic for the optional `optimizer_k` more robust and avoid masking unrelated errors with broad exception handling.
- Ensure checkpoint loading only runs when `optimizer_k` is initialized and the checkpoint file actually exists.

### Description
- Added a guard so the `optimizer_k` checkpoint-loading block only executes when `optimizer_k is not None`.
- Replaced the previous `try/except FileNotFoundError` approach with an explicit `Path(optim_k_path).exists()` check before calling `optimizer_k.load_state_dict(...)`.
- Improved the log message to clearly state when the `optim_k` file is missing and that a new optimizer will be created.

### Testing
- Ran `python -m py_compile train_eval.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b78f93440c8322bce4624a4983091c)